### PR TITLE
Fix task creation validation errors

### DIFF
--- a/routes/taskroutes.js
+++ b/routes/taskroutes.js
@@ -10,8 +10,24 @@ taskRouter.post(
   "/",
   verifyUser,
   [
-    body("title").notEmpty().withMessage("Title is required"),
-    body("due_date").notEmpty().isISO8601().withMessage("Due date must be a valid date"),
+    body("title").trim().notEmpty().withMessage("Title is required").bail(),
+    // Accept either due_date or dueDate from clients; normalize to due_date
+    body("due_date")
+      .customSanitizer((value, { req }) => {
+        if (value) return value;
+        if (req.body && req.body.dueDate) {
+          req.body.due_date = req.body.dueDate;
+          return req.body.dueDate;
+        }
+        return value;
+      })
+      .notEmpty()
+      .withMessage("Due date is required")
+      .bail()
+      .isISO8601({ strict: true })
+      .withMessage("Due date must be a valid date"),
+    body("description").optional().isString().withMessage("Description must be a string"),
+    body("priority").optional().isIn(["Low", "Medium", "High"]).withMessage("Priority must be Low, Medium, or High"),
     body("category").optional().isString().withMessage("Category must be a string"),
   ],
   createTask
@@ -23,7 +39,8 @@ taskRouter.put(
   "/:id",
   verifyUser,
   [
-    body("title").notEmpty().withMessage("Title is required"),
+    body("title").trim().notEmpty().withMessage("Title is required").bail(),
+    body("due_date").optional().isISO8601({ strict: true }).withMessage("Due date must be a valid date"),
     body("status").notEmpty().withMessage("Status is required"),
   ],
   updateTask


### PR DESCRIPTION
Enhance server-side task validation to be more robust against client-side payload inconsistencies and improve date validation.

The previous validation was strict about `due_date` and did not handle cases where clients might send `dueDate` or whitespace-only titles. This update adds a custom sanitizer to accept both `due_date` and `dueDate`, trims the title field, and applies stricter ISO8601 date validation. These changes make the API more resilient to variations in client-side data submission, addressing issues like the reported "Title is required" and "Due date must be a valid date" errors that could arise from malformed or unexpected payloads.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c11cdc7-bf9d-4d4e-94e1-1f52a5416402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c11cdc7-bf9d-4d4e-94e1-1f52a5416402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

